### PR TITLE
Add Grafana Ingress configuration for Kubernetes

### DIFF
--- a/k8s/grafana.yaml
+++ b/k8s/grafana.yaml
@@ -45,14 +45,31 @@ spec:
         ports:
         - containerPort: 3000
         volumeMounts:
+        - name: grafana-pvc
+          mountPath: /var/lib/grafana
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources
           readOnly: true
       volumes:
+      - name: grafana-pvc
+        persistentVolumeClaim:
+          claimName: grafana-pvc
       - name: grafana-datasources
         configMap:
           defaultMode: 420
           name: grafana-datasources
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 512Mi
+  storageClassName: standard
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/grafana_ingress.yaml
+++ b/k8s/grafana_ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: grafana.rat-pay.online
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000


### PR DESCRIPTION
rat-pay.online is a single domain SSL certificate so grafana.rat-pay.online will only be available via HTTP